### PR TITLE
"이메일로 로그인" 페이지에 RHF와 zod 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,12 +16,14 @@
         "qs": "^6.14.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-hook-form": "^7.56.4",
         "react-router-dom": "^7.6.0",
         "sanitize.css": "^13.0.0",
         "storybook": "^8.6.12",
         "styled-components": "^6.1.18",
         "uuid": "^11.1.0",
-        "vite-plugin-compression": "^0.5.1"
+        "vite-plugin-compression": "^0.5.1",
+        "zod": "^3.25.28"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -4165,6 +4167,22 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.56.4",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.56.4.tgz",
+      "integrity": "sha512-Rob7Ftz2vyZ/ZGsQZPaRdIefkgOSrQSPXfqBdvOPwJfoGnjwRJUs7EM7Kc1mcoDv3NOtqBzPGbcMB8CGn9CKgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -5195,10 +5213,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
-      "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
-      "dev": true,
+      "version": "3.25.28",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.28.tgz",
+      "integrity": "sha512-/nt/67WYKnr5by3YS7LroZJbtcCBurDKKPBPWWzaxvVCGuG/NOsiKkrjoOhI8mJ+SQUXEbUzeB3S+6XDUEEj7Q==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
+        "@hookform/resolvers": "^5.0.1",
         "@tanstack/react-query": "^5.76.0",
         "@tanstack/react-query-devtools": "^5.76.0",
         "axios": "^1.9.0",
@@ -917,6 +918,18 @@
         "react": ">= 16 || ^19.0.0-rc"
       }
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.0.1.tgz",
+      "integrity": "sha512-u/+Jp83luQNx9AdyW2fIPGY6Y7NG68eN2ZW8FOJYL+M0i4s49+refdJdOp/A9n9HFQtQs3HIDHQvX3ZET2o7YA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1355,6 +1368,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@storybook/core": {
       "version": "8.6.12",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
+    "@hookform/resolvers": "^5.0.1",
     "@tanstack/react-query": "^5.76.0",
     "@tanstack/react-query-devtools": "^5.76.0",
     "axios": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -18,12 +18,14 @@
     "qs": "^6.14.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-hook-form": "^7.56.4",
     "react-router-dom": "^7.6.0",
     "sanitize.css": "^13.0.0",
     "storybook": "^8.6.12",
     "styled-components": "^6.1.18",
     "uuid": "^11.1.0",
-    "vite-plugin-compression": "^0.5.1"
+    "vite-plugin-compression": "^0.5.1",
+    "zod": "^3.25.28"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/components/common/input/AuthInput.tsx
+++ b/src/components/common/input/AuthInput.tsx
@@ -1,12 +1,18 @@
-import React from 'react';
 import * as S from './AuthInput.styled';
+import { type UseFormRegister } from 'react-hook-form';
+import type { LoginSchemeType } from '../../../constants/authZodConstants';
 
 interface AuthInputProps {
+  name: 'email' | 'password';
+  register: UseFormRegister<LoginSchemeType>;
   placeholder: string;
+  type: 'text' | 'password';
 }
 
-const AuthInput = ({ placeholder }: AuthInputProps) => {
-  return <S.Container placeholder={placeholder} />;
+const AuthInput = ({ name, register, placeholder, type }: AuthInputProps) => {
+  return (
+    <S.Container type={type} placeholder={placeholder} {...register(name)} />
+  );
 };
 
 export default AuthInput;

--- a/src/components/common/input/AuthInput.tsx
+++ b/src/components/common/input/AuthInput.tsx
@@ -1,6 +1,6 @@
+import type { LoginSchemeType } from '../../../models/auth';
 import * as S from './AuthInput.styled';
 import { type UseFormRegister } from 'react-hook-form';
-import type { LoginSchemeType } from '../../../constants/authZodConstants';
 
 interface AuthInputProps {
   name: 'email' | 'password';

--- a/src/constants/authZodConstants.ts
+++ b/src/constants/authZodConstants.ts
@@ -3,6 +3,11 @@ import { z } from 'zod';
 const passwordRegex = /^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,25}$/;
 
 export const LoginScheme = z.object({
-  email: z.string().email({ message: '이메일 입력 필요' }),
-  password: z.string().regex(passwordRegex, '특수문자, 영문, 숫자 포함'),
+  email: z.string().email({ message: '올바른 이메일 형식으로 입력 해주세요.' }),
+  password: z
+    .string()
+    .regex(
+      passwordRegex,
+      '총 길이 8~25자, 영문/숫자/특수문자 형태로 입력 해주세요.'
+    ),
 });

--- a/src/constants/authZodConstants.ts
+++ b/src/constants/authZodConstants.ts
@@ -6,5 +6,3 @@ export const LoginScheme = z.object({
   email: z.string().email({ message: '이메일 입력 필요' }),
   password: z.string().regex(passwordRegex, '특수문자, 영문, 숫자 포함'),
 });
-
-export type LoginSchemeType = z.infer<typeof LoginScheme>;

--- a/src/constants/authZodConstants.ts
+++ b/src/constants/authZodConstants.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+const passwordRegex = /^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,25}$/;
+
+export const LoginScheme = z.object({
+  email: z.string().email({ message: '이메일 입력 필요' }),
+  password: z.string().regex(passwordRegex, '특수문자, 영문, 숫자 포함'),
+});
+
+export type LoginSchemeType = z.infer<typeof LoginScheme>;

--- a/src/models/auth.ts
+++ b/src/models/auth.ts
@@ -1,0 +1,4 @@
+import type { z } from 'zod';
+import type { LoginScheme } from '../constants/authZodConstants';
+
+export type LoginSchemeType = z.infer<typeof LoginScheme>;

--- a/src/pages/login/Login.styled.ts
+++ b/src/pages/login/Login.styled.ts
@@ -68,10 +68,24 @@ export const DividerArea = styled.div`
   margin-bottom: 20px;
 `;
 
-export const Divider = styled.hr`
+export const Divider = styled.div`
   width: 60%;
+  position: relative;
+  height: 1px;
   background-color: #ccc;
   opacity: 40%;
+`;
+
+export const Or = styled.span`
+  display: inline-block;
+  position: absolute;
+  top: -10px;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: #b3ffff;
+  padding: 0 5px;
+  color: #666;
+  font-size: 13px;
 `;
 
 export const SocielLoginSentenceArea = styled.div`

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -26,7 +26,9 @@ const Login = () => {
           <S.SpaceArea></S.SpaceArea>
         </S.EmailLoginButton>
         <S.DividerArea>
-          <S.Divider />
+          <S.Divider>
+            <S.Or>or</S.Or>
+          </S.Divider>
         </S.DividerArea>
         <S.SocielLoginSentenceArea>
           <S.SocielLoginSentence>

--- a/src/pages/login/LoginWithEmail.styled.ts
+++ b/src/pages/login/LoginWithEmail.styled.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import AuthInput from '../../components/common/input/AuthInput';
 
 export const Container = styled.div`
@@ -69,9 +69,7 @@ export const LoginCenterArea = styled.div`
 
 export const Line = styled.hr``;
 
-export const LoginEmailInput = styled(AuthInput)``;
-
-export const LoginPwInput = styled(AuthInput)``;
+export const LoginInput = styled(AuthInput)``;
 
 export const LoginButtonArea = styled.div`
   display: flex;
@@ -83,7 +81,6 @@ export const LoginButton = styled.button`
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: #ccc;
   color: rgb(255, 255, 255);
   border-radius: 4px;
   font-weight: 700;
@@ -94,6 +91,13 @@ export const LoginButton = styled.button`
   margin-top: 10px;
   margin-bottom: 30px;
   cursor: pointer;
+
+  ${({ disabled }) =>
+    disabled
+      ? css`
+          background-color: #ccc;
+        `
+      : `background-color : #eee`};
 `;
 
 export const DividerArea = styled.div`

--- a/src/pages/login/LoginWithEmail.tsx
+++ b/src/pages/login/LoginWithEmail.tsx
@@ -2,9 +2,31 @@ import * as S from './LoginWithEmail.styled';
 import arrow_left from '../../assets/arrow_left.svg';
 import { useNavigate } from 'react-router-dom';
 import mainLogo from '../../assets/logo.svg';
+import { useForm } from 'react-hook-form';
+import {
+  LoginScheme,
+  type LoginSchemeType,
+} from '../../constants/authZodConstants';
+import { zodResolver } from '@hookform/resolvers/zod';
 
 const LoginWithEmail = () => {
   const navigate = useNavigate();
+
+  const {
+    handleSubmit: onSubmitLogin,
+    formState: { errors, isValid },
+    register,
+  } = useForm<LoginSchemeType>({
+    resolver: zodResolver(LoginScheme),
+    mode: 'onChange',
+    defaultValues: { email: '', password: '' },
+  });
+
+  const onSubmit = (data: LoginSchemeType) => {
+    console.log(data);
+    console.log(errors);
+  };
+
   return (
     <S.Container>
       <S.Wrapper>
@@ -17,21 +39,33 @@ const LoginWithEmail = () => {
         <S.LogoWrapper>
           <S.Logo src={mainLogo} />
         </S.LogoWrapper>
-        <S.LoginArea>
+        <S.LoginArea onSubmit={onSubmitLogin(onSubmit)}>
           <S.LoginInputArea>
             <S.LoginCenterArea>
-              <S.LoginEmailInput placeholder='이메일 입력' />
+              <S.LoginInput
+                type='text'
+                placeholder='이메일 입력'
+                name='email'
+                register={register}
+              />
               <S.Line />
             </S.LoginCenterArea>
           </S.LoginInputArea>
           <S.LoginInputArea>
             <S.LoginCenterArea>
-              <S.LoginPwInput placeholder='비밀번호 입력' />
+              <S.LoginInput
+                type='password'
+                placeholder='비밀번호 입력'
+                name='password'
+                register={register}
+              />
               <S.Line />
             </S.LoginCenterArea>
           </S.LoginInputArea>
           <S.LoginButtonArea>
-            <S.LoginButton type='submit'>로그인</S.LoginButton>
+            <S.LoginButton type='submit' disabled={!isValid}>
+              로그인
+            </S.LoginButton>
           </S.LoginButtonArea>
         </S.LoginArea>
         <S.DividerArea>

--- a/src/pages/login/LoginWithEmail.tsx
+++ b/src/pages/login/LoginWithEmail.tsx
@@ -3,11 +3,9 @@ import arrow_left from '../../assets/arrow_left.svg';
 import { useNavigate } from 'react-router-dom';
 import mainLogo from '../../assets/logo.svg';
 import { useForm } from 'react-hook-form';
-import {
-  LoginScheme,
-  type LoginSchemeType,
-} from '../../constants/authZodConstants';
+import { LoginScheme } from '../../constants/authZodConstants';
 import { zodResolver } from '@hookform/resolvers/zod';
+import type { LoginSchemeType } from '../../models/auth';
 
 const LoginWithEmail = () => {
   const navigate = useNavigate();


### PR DESCRIPTION
## 📌 Issue

- "이메일로 로그인" 페이지에 유효성 검사와 비제어 컴포넌트를 위한 RHF, zod 라이브러리 추가

- 관련 이슈: close #13 

---

## 🧐 현재 상황

- 사용자가 이메일, 비밀번호를 입력할 때 zod 유효성이 맞을 때만 "로그인 버튼" 활성화.


## 🎯 목표

- 사용자의 이메일과 비밀번호가 올바르게, 회원 가입 형식에 맞게 입력 되었는 지 1차적으로 검증하여 알려주는 역할

## 🛠 작업 내용

- 회원가입 페이지 생성

## 🚀 기타 사항

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 폼 유효성 검사와 상태 관리를 위한 `react-hook-form`과 `zod` 라이브러리 도입으로 로그인 폼의 검증이 강화되었습니다.
    - 이메일과 비밀번호 입력 시 실시간 유효성 검사가 적용됩니다.

- **스타일**
    - 로그인 화면의 구분선이 `div`로 변경되고, 가운데 "or" 텍스트가 오버레이되어 시각적 구분이 개선되었습니다.
    - 버튼의 활성화 상태에 따라 배경색이 변경되어 사용자에게 상태가 명확하게 전달됩니다.

- **리팩터**
    - 입력 컴포넌트가 폼 라이브러리와 연동되어 코드 구조가 간결해지고 유지보수가 용이해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->