### PR TITLE
"이메일로 로그인" 페이지 work-flow 변경

### DIFF
--- a/src/components/common/input/AuthInput.styled.ts
+++ b/src/components/common/input/AuthInput.styled.ts
@@ -6,5 +6,11 @@ export const Container = styled.input`
   outline: none;
   font-size: 16px;
   font-weight: 500;
+  color: #ccc;
   padding: 0px;
+
+  &:focus {
+    outline: none;
+    box-shadow: none;
+  }
 `;

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -2,5 +2,8 @@ export const ROUTES = {
   home: '/',
   main: '/main',
   login: '/login',
+  withEmail: '/login/email',
   auth: '/auth',
+  signUp: '/sign-up',
+  changePassword: '/change-password',
 } as const;

--- a/src/hooks/login/useCheckEmail.ts
+++ b/src/hooks/login/useCheckEmail.ts
@@ -1,0 +1,23 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ROUTES } from '../../constants/routes';
+
+const exists = false;
+
+const useCheckEmail = () => {
+  const navigate = useNavigate();
+  const [emailExists, setEmailExists] = useState<boolean>(false);
+
+  const checkEmail = (email: string) => {
+    //이메일 존재 여부 로직
+    if (exists) {
+      setEmailExists(true);
+    } else {
+      navigate(ROUTES.signUp, { state: { email } });
+    }
+  };
+
+  return { emailExists, checkEmail };
+};
+
+export default useCheckEmail;

--- a/src/pages/changePassword/ChangePassword.styled.ts
+++ b/src/pages/changePassword/ChangePassword.styled.ts
@@ -1,0 +1,3 @@
+import styled from 'styled-components';
+
+export const Container = styled.div``;

--- a/src/pages/changePassword/ChangePassword.tsx
+++ b/src/pages/changePassword/ChangePassword.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import * as S from './ChangePassword.styled';
+
+const ChangePassword = () => {
+  return <S.Container>ChangePassword Component</S.Container>;
+};
+
+export default ChangePassword;

--- a/src/pages/login/LoginWithEmail.styled.ts
+++ b/src/pages/login/LoginWithEmail.styled.ts
@@ -1,5 +1,6 @@
 import styled, { css } from 'styled-components';
 import AuthInput from '../../components/common/input/AuthInput';
+import { Link } from 'react-router-dom';
 
 export const Container = styled.div`
   width: 100%;
@@ -54,7 +55,7 @@ export const Logo = styled.img`
 export const LoginArea = styled.form`
   display: flex;
   flex-direction: column;
-  padding: 0px 57px;
+  padding: 0px 50px;
 `;
 
 export const LoginInputArea = styled.div`
@@ -62,26 +63,48 @@ export const LoginInputArea = styled.div`
   justify-content: center;
 `;
 
-export const LoginCenterArea = styled.div`
-  width: 80%;
-  margin-bottom: 25px;
+export const Line = styled.hr`
+  width: 100%;
+  height: 2px;
+  background-color: #ccc;
+  opacity: 40%;
 `;
 
-export const Line = styled.hr``;
+export const LoginCenterArea = styled.div<{ $emailExists: boolean }>`
+  width: 100%;
+  visibility: ${({ $emailExists }) => ($emailExists ? 'visible' : 'hidden')};
+  margin-bottom: 60px;
 
-export const LoginInput = styled(AuthInput)``;
+  &:focus-within ${Line} {
+    transform: scaleX(1);
+    background-color: #ff614d;
+    opacity: 1;
+  }
+`;
+
+export const LoginInput = styled(AuthInput)`
+  margin-top: 15px;
+`;
+
+export const InputLabelArea = styled.div`
+  margin-bottom: 10px;
+`;
+
+export const InputLabel = styled.label`
+  font-weight: 600;
+`;
 
 export const LoginButtonArea = styled.div`
   display: flex;
   justify-content: center;
 `;
 
-export const LoginButton = styled.button`
-  width: 80%;
+export const SubmitButton = styled.button`
+  width: 100%;
   display: flex;
   justify-content: center;
   align-items: center;
-  color: rgb(255, 255, 255);
+  color: #ffffff;
   border-radius: 4px;
   font-weight: 700;
   height: 3rem;
@@ -97,32 +120,40 @@ export const LoginButton = styled.button`
       ? css`
           background-color: #ccc;
         `
-      : `background-color : #eee`};
+      : `background-color : #FF614D`};
 `;
 
-export const DividerArea = styled.div`
+export const DividerArea = styled.div<{ $emailExists: boolean }>`
   display: flex;
   justify-content: center;
-  margin-bottom: 20px;
+  margin-bottom: 18px;
+  visibility: ${({ $emailExists }) => ($emailExists ? 'visible' : 'hidden')};
 `;
 
 export const Divider = styled.hr`
-  width: 47%;
+  width: 53%;
   background-color: #ccc;
   opacity: 40%;
 `;
 
-export const OtherOptions = styled.div`
+export const OtherOptions = styled.div<{ $emailExists: boolean }>`
   display: flex;
   justify-content: space-between;
   align-items: center;
   width: fit-content;
   gap: 0.5rem;
   margin: 0 auto;
+  visibility: ${({ $emailExists }) => ($emailExists ? 'visible' : 'hidden')};
 `;
 
 export const Divide = styled.p``;
 
-export const SignUPButton = styled.button``;
+export const SignUpButton = styled(Link)`
+  font-size: 15px;
+`;
 
-export const ChangePwButton = styled.button``;
+export const ChangePwButton = styled(Link)`
+  text-decoration: underline;
+  color: #3705ff;
+  font-size: 15px;
+`;

--- a/src/pages/login/LoginWithEmail.tsx
+++ b/src/pages/login/LoginWithEmail.tsx
@@ -6,6 +6,8 @@ import { useForm } from 'react-hook-form';
 import { LoginScheme } from '../../constants/authZodConstants';
 import { zodResolver } from '@hookform/resolvers/zod';
 import type { LoginSchemeType } from '../../models/auth';
+import { ROUTES } from '../../constants/routes';
+import useCheckEmail from '../../hooks/login/useCheckEmail';
 
 const LoginWithEmail = () => {
   const navigate = useNavigate();
@@ -14,16 +16,23 @@ const LoginWithEmail = () => {
     handleSubmit: onSubmitLogin,
     formState: { errors, isValid },
     register,
+    getValues,
+    watch,
   } = useForm<LoginSchemeType>({
     resolver: zodResolver(LoginScheme),
     mode: 'onChange',
     defaultValues: { email: '', password: '' },
   });
 
+  const { checkEmail, emailExists } = useCheckEmail();
+
   const onSubmit = (data: LoginSchemeType) => {
     console.log(data);
     console.log(errors);
   };
+
+  const email = watch('email');
+  const isEmailValid = !!email && !errors.email;
 
   return (
     <S.Container>
@@ -39,7 +48,10 @@ const LoginWithEmail = () => {
         </S.LogoWrapper>
         <S.LoginArea onSubmit={onSubmitLogin(onSubmit)}>
           <S.LoginInputArea>
-            <S.LoginCenterArea>
+            <S.LoginCenterArea $emailExists={true}>
+              <S.InputLabelArea>
+                <S.InputLabel>이메일</S.InputLabel>
+              </S.InputLabelArea>
               <S.LoginInput
                 type='text'
                 placeholder='이메일 입력'
@@ -49,8 +61,12 @@ const LoginWithEmail = () => {
               <S.Line />
             </S.LoginCenterArea>
           </S.LoginInputArea>
+
           <S.LoginInputArea>
-            <S.LoginCenterArea>
+            <S.LoginCenterArea $emailExists={emailExists}>
+              <S.InputLabelArea>
+                <S.InputLabel>비밀번호</S.InputLabel>
+              </S.InputLabelArea>
               <S.LoginInput
                 type='password'
                 placeholder='비밀번호 입력'
@@ -60,20 +76,33 @@ const LoginWithEmail = () => {
               <S.Line />
             </S.LoginCenterArea>
           </S.LoginInputArea>
+
           <S.LoginButtonArea>
-            <S.LoginButton type='submit' disabled={!isValid}>
-              로그인
-            </S.LoginButton>
+            {emailExists ? (
+              <S.SubmitButton type='submit' disabled={!isValid}>
+                로그인
+              </S.SubmitButton>
+            ) : (
+              <S.SubmitButton
+                type='button'
+                onClick={() => checkEmail(getValues('email'))}
+                disabled={!isEmailValid}
+              >
+                다음 이동
+              </S.SubmitButton>
+            )}
           </S.LoginButtonArea>
+          <>
+            <S.DividerArea $emailExists={emailExists}>
+              <S.Divider />
+            </S.DividerArea>
+            <S.OtherOptions $emailExists={emailExists}>
+              <S.ChangePwButton to={ROUTES.changePassword}>
+                비밀번호를 잊어버리셨나요?
+              </S.ChangePwButton>
+            </S.OtherOptions>
+          </>
         </S.LoginArea>
-        <S.DividerArea>
-          <S.Divider />
-        </S.DividerArea>
-        <S.OtherOptions>
-          <S.SignUPButton>계정 생성하기</S.SignUPButton>
-          <S.Divide>|</S.Divide>
-          <S.ChangePwButton>비밀번호 재설정</S.ChangePwButton>
-        </S.OtherOptions>
       </S.Wrapper>
     </S.Container>
   );

--- a/src/pages/signup/SignUp.styled.ts
+++ b/src/pages/signup/SignUp.styled.ts
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  width: 100%;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+`;
+
+export const Wrapper = styled.div`
+  max-width: 450px;
+  width: 100%;
+  min-height: 500px;
+  padding: 30px 30px;
+  background-color: #b3ffff;
+  border-radius: 20px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+`;

--- a/src/pages/signup/SignUp.tsx
+++ b/src/pages/signup/SignUp.tsx
@@ -1,0 +1,11 @@
+import * as S from './SignUp.styled';
+
+const SignUp = () => {
+  return (
+    <S.Container>
+      <S.Wrapper></S.Wrapper>
+    </S.Container>
+  );
+};
+
+export default SignUp;

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -4,6 +4,8 @@ import Layout from '../layout/Layout';
 import Login from '../pages/login/Login';
 import OauthCheckComponent from '../components/OauthCheckComponent/OauthCheckComponent';
 import LoginWithEmail from '../pages/login/LoginWithEmail';
+import SignUp from '../pages/signup/SignUp';
+import ChangePassword from '../pages/changePassword/ChangePassword';
 
 const AppRoutes = () => {
   const routeList = [
@@ -29,6 +31,22 @@ const AppRoutes = () => {
       element: (
         <Layout>
           <OauthCheckComponent />
+        </Layout>
+      ),
+    },
+    {
+      path: `${ROUTES.signUp}`,
+      element: (
+        <Layout>
+          <SignUp />
+        </Layout>
+      ),
+    },
+    {
+      path: `${ROUTES.changePassword}`,
+      element: (
+        <Layout>
+          <ChangePassword />
         </Layout>
       ),
     },


### PR DESCRIPTION
## 📌 Issue

- "이메일로 로그인" 페이지의 work-flow를 기존 방식에서 이메일을 기준으로 flow가 진행되게 변경

- 입력된 이메일이 회원인 경우(바로 로그인 할 수 있도록 조치)
https://github.com/user-attachments/assets/413c5a6a-212d-4b85-b5e4-4bde56a0da62

- 입력된 이메일이 회원이 아닌 경우(바로 회원가입 페이지로 이동)
https://github.com/user-attachments/assets/0e43afef-8894-4e2f-af2e-6a345a0ac729

- 입력 폼 클릭 시 발생했던 불필요한 외곽 둘레 제거

- 관련 이슈: close #16 

---

## 🧐 현재 상황

- 테마색 이슈
- 회원가입 페이지, 비밀번호 재설정 페이지 필요

---

## 🎯 목표

- "이메일로 로그인" 페이지를 해당 work-flow로 변경하여 효율적으로 사용자의 UX 관리

---

## 🛠 작업 내용

---

## 🚀 기타 사항

- 라프텔의 work-flow 참고
https://laftel.net/auth/login?next=/?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 이메일로 로그인 시 이메일 존재 여부를 확인하는 기능이 추가되었습니다.
  - 회원가입 및 비밀번호 변경 페이지가 새롭게 추가되었습니다.
  - 이메일 존재 여부에 따라 로그인 폼의 입력 및 버튼 동작이 달라집니다.

- **스타일**
  - 로그인, 회원가입, 비밀번호 변경 페이지의 UI가 개선되고 스타일이 추가되었습니다.
  - 입력창, 버튼, 라벨 등 다양한 컴포넌트의 시각적 요소가 향상되었습니다.

- **버그 수정**
  - 입력창 포커스 시 불필요한 외곽선과 그림자가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->